### PR TITLE
Added Commands to list and install PHP versions

### DIFF
--- a/app/Commands/PhpInstallVersionCommand.php
+++ b/app/Commands/PhpInstallVersionCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Commands;
+
+use App\Support\PhpVersion;
+
+class PhpInstallVersionCommand extends Command
+{
+    use Concerns\InteractsWithPhp;
+
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'php:install {version}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Install a new php version';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->ensurePhpExists();
+
+        $server = $this->currentServer();
+
+        $version = $this->argument('version');
+        $versions = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'];
+
+        if (! is_null($version) && ! in_array($version, $versions, true)) {
+            abort(1, 'PHP version needs to be one of these values: '.implode(', ', $versions).'.');
+        }
+
+        $version = $version ?: PhpVersion::of($server->phpVersion)->release();
+
+        if(collect($this->forge->phpVersions($server->id))->firstWhere('binaryName', 'php'.$version)) {
+            abort(1, 'This PHP version is already installed on your server.');
+        }
+
+        $this->step('Queuing installation of PHP '.$version);
+        $this->step('Check you installed PHP versions via php:list');
+    }
+}

--- a/app/Commands/PhpVersionListCommand.php
+++ b/app/Commands/PhpVersionListCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Commands;
+
+class PhpVersionListCommand extends Command
+{
+    use Concerns\InteractsWithPhp;
+
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'php:list';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'List the php versions';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->ensurePhpExists();
+
+        $server = $this->currentServer();
+        $this->step('Retrieving the list of php versions');
+
+        $this->table([
+            'Version', 'Status', 'On CLI', 'Is Default',
+        ], collect($this->forge->phpVersions($server->id))->map(function ($phpVersion) {
+
+            $status = $phpVersion->usedOnCli ? '<fg=green>√</>' : '<fg=red>x</>';
+            $default = $phpVersion->usedAsDefault ? '<fg=green>√</>' : '<fg=red>x</>';
+
+            return [
+                $phpVersion->displayableVersion,
+                $phpVersion->status,
+                $status,
+                $default,
+            ];
+        })->all());
+    }
+}


### PR DESCRIPTION
Hi there,

we havent done any changes for a while.

Since we handle a lot of servers now, it's become quite dificult to handle them all.
With this change, it is now possible to list all installed PHP versions of the current server and also install new versions.

The console will stay open so you can watch the installation process.

For a futre update it would be nice, to use the CLI to switch the global PHP version. So you can change it eg to PHP 8.3 without login to Dashboard.

Thanks!